### PR TITLE
python3 luma install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 echo "Install Luma.core drivers"
 apt update --fix-missing
 apt install python3.7-dev python3-pip libfreetype6-dev libjpeg-dev dsniff mitmproxy -y
-pip3 install --upgrade luma.oled
-pip3 install --upgrade luma.core
+apt install --upgrade python3-luma.oled
+apt install --upgrade python3-luma.core
 echo "Create directories"
 mkdir -p /root/BeBoXGui/{images,nmap}
 echo "Copying files"


### PR DESCRIPTION
pip3 doesn't work. You have to use apt and python-xyz. This fixes the errors when running ./install.sh